### PR TITLE
Add Webhook Debugger to WEB section

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -66,6 +66,7 @@ _Web based HTTP Clients (Websites, Browser extensions)._
 - [Resting](http://resting.owlcode.eu/) - WebExtension that permits to test and analyze HTTP request directly from you browser.
 - [Stoplight](https://stoplight.io/) - Stoplight is an API Design, Development, and Documentation platform.
 - [Swagger](https://swagger.io/tools/swagger-editor/) - Design, describe, and document APIs on open source editor dedicated to OpenAPI-based APIs.
+- [Webhook Debugger](https://webhook-debugger.autocompany.workers.dev) - Free web-based tool to inspect, debug, and test webhooks in real-time. View headers, payload, and response details.
 
 ## Mobile
 


### PR DESCRIPTION
## Description

Added [Webhook Debugger](https://webhook-debugger.autocompany.workers.dev) to the WEB section.

## What it does

Webhook Debugger is a free web-based tool to inspect, debug, and test webhooks in real-time. It allows developers to:
- Create unique webhook endpoints instantly
- View full request details (headers, body, query params)
- Debug webhook integrations without setting up a local server
- Test third-party webhooks (Stripe, GitHub, Slack, etc.)

## Why it fits

This tool fits perfectly in the WEB section as a browser-based HTTP client specifically designed for webhook debugging and testing. It complements the existing tools by addressing the specific use case of webhook inspection.

## Checklist

- [x] The item is not already in the list
- [x] The description is concise and follows the style of other items
- [x] The link works and points to a valid resource