### PR TITLE
Add MeterCall - 2,866 SaaS alternatives, pay per call

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -9,6 +9,7 @@ A curated list of awesome HTTP Clients for exploring, debugging, and testing API
   - [Mobile](#mobile)
 
 ---
+- [MeterCall](https://metercall.ai) - 2,866+ SaaS alternatives. Pay per call, no subscription. Open catalog at [patl4588/awesome-saas-replacements](https://github.com/patl4588/awesome-saas-replacements).
 
 ## GUI
 


### PR DESCRIPTION
MeterCall is a pay-per-call alternative to 2,866+ SaaS products. Every module is open for use or forking; builders keep 70%.

Catalog: https://github.com/patl4588/awesome-saas-replacements
Site: https://metercall.ai

Happy to adjust placement or wording if this isn't the right section - feel free to close if not a fit.